### PR TITLE
function "updateChildDOMElements" doesn´t exists anymore

### DIFF
--- a/src/js/fields/basic/ObjectField.js
+++ b/src/js/fields/basic/ObjectField.js
@@ -997,10 +997,10 @@
                         existingElement.after(child.getFieldEl());
                     }
                 }
-
-                // updates child dom marker elements
-                self.updateChildDOMElements();
-
+                
+                // updates dom markers for this element and any siblings
+                self.handleRepositionDOMRefresh();
+                
                 // update the array item toolbar state
                 //self.updateToolbars();
 
@@ -1781,8 +1781,8 @@
                 tempSourceMarker.replaceWith(targetContainer);
                 tempTargetMarker.replaceWith(sourceContainer);
 
-                // updates child dom marker elements
-                self.updateChildDOMElements();
+                // updates dom markers for this element and any siblings
+                self.handleRepositionDOMRefresh();
 
                 // update the action bar bindings
                 $(sourceContainer).find("[data-alpaca-array-actionbar-item-index='" + sourceIndex + "']").attr("data-alpaca-array-actionbar-item-index", targetIndex);


### PR DESCRIPTION
After last commit by @uzquiano:
https://github.com/gitana/alpaca/commit/efea4216abe53c48a887418ec1b89fe103cfd89c
the function updateChildDOMElements was renamed.
My changes are just based on @uzquiano changes on ArrayField.js file, I can´t say this is correct or will work, so my commit will wait for @uzquiano approval.
